### PR TITLE
Async :wait_local functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Example:
             async :wait
         end
     end
+   
 
 The above example shows how you might use the async/wait syntax within a save method of a user model to split the blocking calls
 of storing the user & permissions data in the database and updating the cache. The example above also shows how the set cache async block can be
@@ -74,69 +75,33 @@ Using the above async flow if we look at the execution time required for each of
 
 In a sync flow the `save` method would take approx 260ms (100+120+40), but via async it should take no more than 120ms.
 
-The following environment variable can be used to specify the async task pool size:
+
+#### Environment Variables
 
 - **PWORK_ASYNC_POOL_SIZE** [Integer] [Optional] [Default=10] 
+> This env var is used to specify the async task pool size
+
+- **PWORK_ASYNC_WAIT_SLEEP_ITERATION** [Integer] [Optional] [Default=0.01] 
+> This env var is used to specify the time between wait intervals when waiting for async tasks to complete
+
+#### Methods
+
+#### `async do`
+
+This is used to define a async task block that should be executed asynchronously within the task pool.
+
+#### `async :wait`
+
+This is used to wait for all async tasks declared from the current thread to complete.
+
+#### `async :wait_local`
+
+This is used to wait for all async tasks declared from the current object on the current thread to complete.
+
+> This is useful to allow async/wait not to interfere with other async calls from within other objects)
+
 
 > This is the number of threads within the async pool to use for processing async tasks           
-
-### .peach
-> This functionality is now deprecated in favour of the Async/Await model detailed above.
-
-This method provides a parallel thread based execution of an each block iteration over an array.
-
-**Params:**
-
- - **thread_count** [Integer] [Optional] [Default=5] This is the number of threads that the parallel iteration should be spread across.
-
-**Example:**
-
-	#array each iteration using the default thread count
-    array.peach do |item|
-	    ......
-	end
-
-	#array each iteration using a specified thread count
-	array.peach(8) do |item|
-		......
-	end
-
-### PWork::Worker
-
-> This functionality is now deprecated in favour of the Async/Await model detailed above.
-
-The worker object is used to attach one or more blocks of code to execute in parallel.
-The number of threads to spread the parallel execution across can be specified in the workers construction.
-
-**Params:**
-
- - **thread_count** [Integer] [Optional] [Default=5] This is the number of threads that the parallel execution should be spread across.
-
-**Example:**
-
-    #create a worker with the default number of parallel threads
-    worker = Pwork::Worker.new
-
-    #create a worker with a specific number of parallel threads
-    worker = Pwork::Worker.new(threads: 8)
-
-Then add your blocks of code to execute in parallel:
-
-    worker.add do
-	    .......
-	end
-
-	worker.add do
-		.......
-	end
-
-Once all blocks of code required to be executed in parallel have been added to the worker, a call to the execute method is required to begin processing:
-
-    worker.execute
-
-All blocks of code will be executed in parallel across the workers threads.
-
-> The Worker object is not asynchronous, the worker processes are executed on separate threads in parallel but the worker execute method is synchronous and will wait until all execution has completed before continuing past the **worker.execute** call line.
 
 ## Development
 

--- a/lib/pwork/async.rb
+++ b/lib/pwork/async.rb
@@ -9,9 +9,6 @@ module PWork
         options[:caller] = self
         PWork::Async.add_task(options, &block)
       else
-        raise PWork::Async::Exceptions::InvalidOptionsError.new(
-          'Unknown async option.'
-        ) unless options == :wait || options == :wait_local
         PWork::Async.wait_for_tasks({ caller: self, command: options })
       end
     end

--- a/lib/pwork/async.rb
+++ b/lib/pwork/async.rb
@@ -4,14 +4,15 @@ require_relative 'async/manager'
 
 module PWork
   module Async
-    def async(options = nil, &block)
+    def async(options = {}, &block)
       if block_given?
+        options[:caller] = self
         PWork::Async.add_task(options, &block)
       else
         raise PWork::Async::Exceptions::InvalidOptionsError.new(
           'Unknown async option.'
-        ) unless options == :wait
-        PWork::Async.wait_for_tasks
+        ) unless options == :wait || options == :wait_local
+        PWork::Async.wait_for_tasks({ caller: self, command: options })
       end
     end
 
@@ -22,9 +23,9 @@ module PWork
     def self.add_task(options, &block)
       manager.start unless manager.running
 
-      options = {} if options == nil
       task = PWork::Async::Task.new.tap do |e|
         e.block = block
+        e.caller = options[:caller]
       end
 
       unless options[:wait] == false
@@ -40,11 +41,20 @@ module PWork
       Thread.current[:pwork_async_tasks] ||= []
     end
 
-    def self.wait_for_tasks
-      until tasks.detect { |t| t.state == :pending || t.state == :active }.nil?
+    def self.wait_for_tasks(options)
+      case options[:command]
+        when :wait
+          task_list = tasks
+        when :wait_local
+          task_list = tasks.select { |t| t.caller == options[:caller] }
+      end
+
+      until task_list.detect { |t| t.state == :pending || t.state == :active }.nil?
         sleep(async_wait_sleep_iteration)
       end
+
       handle_errors
+
       ensure
         Thread.current[:pwork_async_tasks] = []
     end
@@ -54,7 +64,9 @@ module PWork
       tasks.select { |t| t.state == :error }.each do |t|
         error_messages << "Error: #{t.error.message}, #{t.error.backtrace}"
       end
-      raise PWork::Async::Exceptions::TaskError.new("1 or more async errors occurred. #{error_messages.join(' | ')}") if error_messages.length > 0
+      raise PWork::Async::Exceptions::TaskError.new(
+        "1 or more async errors occurred. #{error_messages.join(' | ')}"
+      ) if error_messages.length > 0
       true
     end
 

--- a/lib/pwork/async/task.rb
+++ b/lib/pwork/async/task.rb
@@ -7,6 +7,7 @@ module PWork
       attr_accessor :thread_local_storage
       attr_accessor :error
       attr_accessor :block
+      attr_accessor :caller
       def initialize
         self.id = SecureRandom.uuid
         self.state = :pending

--- a/spec/pwork/async/async_wait_local_example_spec.rb
+++ b/spec/pwork/async/async_wait_local_example_spec.rb
@@ -1,0 +1,55 @@
+class ExampleClient2
+  include PWork::Async
+
+  def http_method
+    # sleep for 20s to simulate avery long blocking http call
+    sleep(20)
+  end
+
+  def multi_call_async
+    async do
+      http_method
+    end
+    async do
+      http_method
+    end
+  end
+end
+
+class ExampleClient3
+  include PWork::Async
+
+  def http_method
+    # sleep for 20s to simulate avery long blocking http call
+    sleep(0.2)
+  end
+
+  def multi_call_async
+    async do
+      http_method
+    end
+    async do
+      http_method
+    end
+    async do
+      http_method
+    end
+    async do
+      http_method
+    end
+  end
+
+  def wait
+    async :wait_local
+  end
+end
+
+RSpec.describe ExampleClient3 do
+  it 'makes multiple http calls asyncronously' do
+    ExampleClient2.new.multi_call_async
+    subject.multi_call_async
+    expect(PWork::Async.tasks.length).to eq 6
+    subject.wait
+    expect(PWork::Async.tasks.length).to eq 0
+  end
+end


### PR DESCRIPTION
Added `async :wait_local` functionality to allow async wait calls to be made relative to async tasks within the current object.