### PR TITLE
Bugfix - `async :wait_local`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ In a sync flow the `save` method would take approx 260ms (100+120+40), but via a
 
 > `test` mode processes tasks synchronously and is useful for testing.
 
-- **PWORK_ASYNC_WAIT_SLEEP_ITERATION** [Integer] [Optional] [Default=0.01] 
-> This env var is used to specify the time between wait intervals when waiting for async tasks to complete
-
 #### Methods
 
 #### `async do`

--- a/lib/pwork/async.rb
+++ b/lib/pwork/async.rb
@@ -78,7 +78,7 @@ module PWork
       handle_errors
 
       ensure
-        Thread.current[:pwork_async_tasks] = []
+        Thread.current[:pwork_async_tasks] -= task_list
     end
 
     def self.handle_errors

--- a/spec/pwork/async/async_wait_local_example_spec.rb
+++ b/spec/pwork/async/async_wait_local_example_spec.rb
@@ -53,6 +53,9 @@ RSpec.describe ExampleClient3 do
     subject.multi_call_async
     expect(PWork::Async.tasks.length).to eq 6
     subject.wait
-    expect(PWork::Async.tasks.length).to eq 0
+    expect(PWork::Async.tasks.length).to eq 2
+  end
+  after do
+    PWork::Async.reset
   end
 end


### PR DESCRIPTION
Resolved bug that caused async :wait_local to clear non local async tasks from the wait list